### PR TITLE
Do not elide key/cert/ca information if tls verification is disabled

### DIFF
--- a/libraries/consul_acl.rb
+++ b/libraries/consul_acl.rb
@@ -91,7 +91,7 @@ module ConsulCookbook
 
       def up_to_date?
         retry_block(max_tries: 3, sleep: 0.5) do
-          old_acl = Diplomat::Acl.info(new_resource.to_acl['ID'], nil, :return)
+          old_acl = Diplomat::Acl.info(new_resource.to_acl['ID'], {}, nil, :return)
           return false if old_acl.nil? || old_acl.empty?
           old_acl.first.select! { |k, _v| %w(ID Type Name Rules).include?(k) }
           old_acl.first == new_resource.to_acl

--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -235,7 +235,8 @@ module ConsulCookbook
         )
 
         for_keeps << %i(bootstrap bootstrap_expect) if server
-        for_keeps << %i(ca_file ca_path cert_file key_file) if tls?
+        ssl_config = [ca_file, ca_path, cert_file, key_file]
+        for_keeps << %i(ssl_config.map { |c| c if c and file_exists? c })
         for_keeps = for_keeps.flatten
 
         # Filter out undefined attributes and keep only those listed above
@@ -245,8 +246,8 @@ module ConsulCookbook
         JSON.pretty_generate(Hash[config.sort_by { |k, _| k.to_s }], quirks_mode: true)
       end
 
-      def tls?
-        verify_incoming || verify_incoming_https || verify_incoming_rpc || verify_outgoing
+      def file_exists?(filename)
+        return ::File.exists? filename
       end
 
       action(:create) do

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '9003.1.4'
+version '9003.1.5'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'


### PR DESCRIPTION
Per https://learn.hashicorp.com/consul/advanced/day-1-operations/agent-encryption#enable-tls-existing-cluster
disabling verification while still specifying the ca/cert and key is
in fact the recommended way to perform ssl upgrades. Failure to specify
ssl in an existing cluster risks affecting availability.

Also, delete the `tls?` method, as it is only used to determine when
to exclude the certificate information from the consul configuration.