### PR TITLE
Use consul 1.2.4 by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,10 +37,15 @@ default['consul']['diplomat_version'] = nil
 
 default['consul']['service']['config_dir'] = join_path config_prefix_path, 'conf.d'
 
-default['consul']['version'] = '0.9.3'
+default['consul']['version'] = '1.2.4'
 
+# Our repo for testing enterprise packages.
+# Use this location when testing enterprise.
+# default['consul']['archive_url_root'] = 'https://cdn.aws.robloxlabs.com'
 default['consul']['archive_url_root'] = 'https://releases.hashicorp.com'
 
+# When turning this to true, be sure the enterprise packages are located
+# at archive_url_root.
 default['consul']['enterprise'] = false
 
 # Windows only

--- a/test/integration/spec_helper.rb
+++ b/test/integration/spec_helper.rb
@@ -1,3 +1,3 @@
 def consul_version
-  '0.9.3'
+  '1.2.4'
 end


### PR DESCRIPTION
0.9.3 does not have an enterprise version available, but
consul releases following 1.4.0 use a different acl system
which is incompatible with this library. Enterprise releases
begin at 1.1.0. Setting the version to something that
works for enterprise and OS.