### PR TITLE
Support for Windows using Chef 14

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '9003.1.9'
+version '9003.1.10'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'
@@ -22,7 +22,7 @@ depends 'golang'
 depends 'poise', '~> 2.2'
 depends 'poise-archive', '~> 1.3'
 depends 'poise-service', '~> 1.4'
-depends 'windows', '~> 3.1'
+depends 'windows', '>= 3.1'
 
 source_url 'https://github.com/johnbellone/consul-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/johnbellone/consul-cookbook/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
windows 5.0+ is needed for Chef 14 to start working for Windows OS