### PR TITLE
override systemd-resolved for consul servers

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,12 +12,8 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-16.04
-  - name: ubuntu-14.04
-  - name: centos-7.3
-  - name: centos-6.8
-  - name: debian-9.3
-  - name: debian-8.7
+  - name: ubuntu-18.04
+  - name: centos-7.7
   - name: windows-2012r2
     driver:
       box: mwrock/Windows2012R2
@@ -32,6 +28,12 @@ suites:
     attributes:
       consul:
         config: &default-config
+          ports:
+           dns: 53
+           http: 8500
+           serf_lan: 8301
+           serf_wan: 8302
+           server: 8300
           owner: root
           ui: true
           bootstrap: true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,6 +4,14 @@
 #
 # Copyright 2014-2016, Bloomberg Finance L.P.
 #
+
+case node['platform']
+when 'ubuntu'
+  if node['consul']['config']['server'] === true
+    include_recipe '::systemd-resolved'
+  end
+end
+
 poise_service_user node['consul']['service_user'] do
   group node['consul']['service_group']
   shell node['consul']['service_shell'] unless node['consul']['service_shell'].nil?

--- a/recipes/systemd-resolved.rb
+++ b/recipes/systemd-resolved.rb
@@ -1,0 +1,9 @@
+# undo stub symlink to standard symlink
+link '/etc/resolv.conf' do
+    to '/run/systemd/resolve/resolv.conf'
+end
+
+# Stop and disable systemd-resolved
+systemd_unit 'systemd-resolved.service' do
+    action [:disable, :stop]
+end

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -10,6 +10,13 @@ ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>
 User=<%= @user %>
 WorkingDirectory=<%= @directory %>
+<% if node['consul']['config']['server'] %>
+SecureBits=keep-caps
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+Capabilities=CAP_NET_BIND_SERVICE=+ep
+CapabilityBoundingSet=CAP_SYSLOG CAP_NET_BIND_SERVICE
+<% end %>
+
 
 [Install]
 WantedBy=multi-user.target

--- a/test/fixtures/cookbooks/consul_spec/recipes/consul_definition.rb
+++ b/test/fixtures/cookbooks/consul_spec/recipes/consul_definition.rb
@@ -14,7 +14,7 @@ consul_definition 'consul_definition_check' do
   type 'check'
   user 'root'
   parameters(id: 'consul_definition_check',
-             script: '/consul_definition_check.rb',
+             args: ['/consul_definition_check.rb'],
              interval: '10s',
              timeout: '10s')
   notifies :reload, 'consul_service[consul]', :delayed

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -30,7 +30,9 @@ describe service('consul') do
   it { should be_running }
 end
 
-[8300, 8500, 8600].each do |p|
+#dns_port = node['consul']['config']['ports']['dns']
+
+[8300, 8500, 53].each do |p|
   describe port(p) do
     it { should be_listening }
   end


### PR DESCRIPTION
# Description

This change allows management of systemd-resolved based hosts to run Consul on port 53 to get authoritative DNS on the .consul zone as simple as possible.

## Issues Resolved

Allows management of systemd-resolved based hosts (Ubuntu 18.04).

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
