### PR TITLE
change systemd template to wait for network to come online before sta…

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '9003.1.11'
+version '9003.1.12'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -1,7 +1,7 @@
 [Unit]
 Description=<%= @name %>
-Wants=network.target
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Environment=<%= @environment.map {|key, val| %Q{"#{key}=#{val}"} }.join(' ') %>


### PR DESCRIPTION
Ubuntu systems in CHI1 aren't waiting for the network to start up properly before starting.  But can change this for all systems

More info here:  https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/