### PR TITLE
Add Restart=Always to consul

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '9003.1.15'
+version '9003.1.16'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -9,6 +9,7 @@ ExecStart=<%= @command %>
 ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>
 Restart=always
+RestartSec="5s"
 User=<%= @user %>
 WorkingDirectory=<%= @directory %>
 <% if node['consul']['config']['server'] %>

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -8,6 +8,7 @@ Environment=<%= @environment.map {|key, val| %Q{"#{key}=#{val}"} }.join(' ') %>
 ExecStart=<%= @command %>
 ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>
+Restart=always
 User=<%= @user %>
 WorkingDirectory=<%= @directory %>
 <% if node['consul']['config']['server'] %>


### PR DESCRIPTION
# Description

This automatically restarts consul if the process exits, is killed, or a timeout is reached. 

## Issues Resolved

This specifically fixes an issue when a portworx client reboots. Consul is in a race condition with portworx and docker and doesn't restart automatically. This change automates that process so there is minimal downtime.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
