### PR TITLE
Fix RestartSec 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '9003.1.16'
+version '9003.1.17'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '9003.1.15'
+version '9003.1.16'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -9,7 +9,7 @@ ExecStart=<%= @command %>
 ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>
 Restart=always
-RestartSec="5s"
+RestartSec=5
 User=<%= @user %>
 WorkingDirectory=<%= @directory %>
 <% if node['consul']['config']['server'] %>

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -9,6 +9,7 @@ ExecStart=<%= @command %>
 ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>
 Restart=always
+RestartSec="5s"
 User=<%= @user %>
 WorkingDirectory=<%= @directory %>
 <% if node['consul']['config']['server'] %>

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -8,6 +8,7 @@ Environment=<%= @environment.map {|key, val| %Q{"#{key}=#{val}"} }.join(' ') %>
 ExecStart=<%= @command %>
 ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>
+Restart=always
 User=<%= @user %>
 WorkingDirectory=<%= @directory %>
 <% if node['consul']['config']['server'] %>


### PR DESCRIPTION
Fix RestartSec:

```bash
# when set to "5s"
/etc/systemd/system/consul.service:12: Failed to parse sec value, ignoring: "5s"
```

Should be 5 instead of 5s